### PR TITLE
Add padding configuration in lvgl.yaml: set pad_all to 0 for improved…

### DIFF
--- a/waveshare-esp32-s3-touch-lcd-7/device/lvgl.yaml
+++ b/waveshare-esp32-s3-touch-lcd-7/device/lvgl.yaml
@@ -372,6 +372,7 @@ lvgl:
                     flex_align_cross: end
                   bg_opa: TRANSP
                   border_width: 0
+                  pad_all: 0
                   widgets:
                     - label:
                         text_font: roboto36_font


### PR DESCRIPTION
… layout consistency in the user interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Print Progress layout by removing extra padding in its container.
> 
> - In `lvgl.yaml`, adds `pad_all: 0` to the `obj` within `print_progress_button` so the `print_progress_label` and `%` label align tightly without unintended spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf7199e3e0bdaaf51cf3a506db45340f903f6d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->