### PR TITLE
Add living room LVGL dashboard for Guition ESP32-P4 JC1060P470

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ESPHome LVGL configuration repository for ESP32 touch LCD displays used in home automation. All configuration is declarative YAML — there is no traditional source code, build system, or test suite. The configs are compiled and flashed via the ESPHome dashboard/CLI.
+
+## Supported Devices
+
+| Device | Chip | Display | Directory |
+|--------|------|---------|-----------|
+| Guition JC1060P470 | ESP32-P4 | 7" MIPI DSI | `guition-esp32-p4-jc1060p470/` |
+| Guition JC4880P443 | ESP32-P4 | 4.8" MIPI DSI | `guition-esp32-p4-jc4880p443/` |
+| Guition JC8012P4A1 | ESP32-P4 | MIPI DSI | `guition-esp32-p4-jc8012p4a1/` |
+| Guition 4848S040 | ESP32-S3 | 4" ST7701S RGB | `guition-esp32-s3-4848s040/` |
+
+Archived: `archived/waveshare-esp32-s3-touch-lcd-7/`
+
+## Architecture
+
+### Two-file entry point
+
+- **`esphome.yaml`** — User-facing template. Sets `substitutions` (name, friendly_name, room), WiFi credentials via `!secret`, and pulls packages from GitHub.
+- **`package.yaml`** — Includes all modular config files via `!include`.
+
+### Per-device directory layout
+
+```
+<device>/
+├── esphome.yaml          # Entry point (substitutions + WiFi + remote package ref)
+├── package.yaml          # Package manifest (!include for each module)
+├── device/
+│   ├── device.yaml       # Hardware: ESP32 variant, display, touchscreen, I2C, PSRAM, backlight output
+│   ├── sensors.yaml      # HA entity bindings: sensor values + binary_sensor → LVGL widget state sync
+│   └── lvgl.yaml         # UI layout: pages, buttons, labels using flex layout
+├── addon/
+│   ├── backlight.yaml    # Screensaver/presence-based backlight control
+│   ├── network.yaml      # WiFi signal, uptime, IP sensors
+│   └── time.yaml         # SNTP time sync + clock label update
+├── assets/
+│   ├── fonts.yaml        # Google Fonts (Roboto) at various sizes
+│   └── icons.yaml        # MDI icon font glyphs + substitution mappings
+├── theme/
+│   └── button.yaml       # Button styling: colors, sizes, checked state via substitutions
+└── spares/               # (P4 devices only) Optional configs: ethernet, sdcard, speaker, voice
+```
+
+### Key hardware differences
+
+- **ESP32-P4 devices** use MIPI DSI displays, `esp32_hosted` for a secondary ESP32-C6 (WiFi/BLE), hex-mode PSRAM at 200MHz, and external components from `p1ngb4ck/esphome@dev`.
+- **ESP32-S3 devices** use ST7701S RGB displays over SPI, have built-in WiFi, and use octal-mode PSRAM at 80MHz.
+
+### UI pattern (LVGL)
+
+The UI uses LVGL flex layout with `column_wrap`. Each control is a `checkable` button with:
+- An icon label (MDI font) at `top_left`
+- A text label at `bottom_left`
+- `on_press`/`on_click` triggers `homeassistant.service` calls
+- Button checked state is synced from HA via `binary_sensor` → `lvgl.widget.update`
+
+Sensors use `platform: homeassistant` to pull entity state. The `on_value` callback updates LVGL labels using `format`/`args` with C-style printf formatting (wrapped in `!lambda` for logic).
+
+### Theming via substitutions
+
+`theme/button.yaml` defines substitutions (`$button_on_color`, `$button_height`, `$button_width`, etc.) and `assets/icons.yaml` maps icon names (`$printer`, `$aircon`, etc.) to MDI Unicode codepoints. These substitutions are referenced throughout `lvgl.yaml`.
+
+## Working with this repo
+
+- **No build/test/lint commands** — validation happens at ESPHome compile time.
+- **To compile**: `esphome compile <device>/esphome.yaml` (requires ESPHome installed).
+- **To flash**: `esphome run <device>/esphome.yaml` (USB) or OTA from the ESPHome dashboard.
+- YAML is the only file type. Changes are validated by compiling against the ESPHome framework.
+- WiFi credentials and other secrets use `!secret` tags and are stored in the ESPHome dashboard secrets, not in this repo.
+
+## Conventions
+
+- The remote package URL in `esphome.yaml` points to `github://jtenniswood/esphome-lvgl/` — when editing, the local files under each device directory are what get published.
+- Icons must be declared in both the `font.glyphs` array and the `substitutions` map in `icons.yaml`.
+- Button IDs in `lvgl.yaml` must have matching binary_sensor entries in `sensors.yaml` to sync checked state.
+- The `spares/` directory contains optional/experimental configs not included in `package.yaml` by default.
+- Stateful Scenes integration (external HA add-on) is used for scene state tracking — scene buttons toggle `switch.*_stateful_scene` entities.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,211 @@
+# Living Room LVGL Dashboard — Implementation Plan
+
+## Context
+
+The Guition ESP32-P4 JC1060P470 (7-inch, 1024×600, MIPI DSI) is already flashed with ESPHome and configured for the Living Room (`esphome.yaml`: name=touch-screen-1, room=Living Room). The existing YAML files contain an **office** dashboard that must be completely replaced with a **living room** dashboard covering lights, blinds, ceiling fan, and entertainment devices.
+
+---
+
+## Page Structure: 3 Pages + Bottom Nav Bar
+
+**Display: 1024×600 px**
+- Top bar: ~40px (temperature + clock, persistent in `top_layer`)
+- Bottom nav bar: ~56px (3 tab icons, persistent in `top_layer`)
+- Content area per page: ~504px tall × 1024px wide
+
+### Bottom Navigation Bar (in `top_layer`)
+3 icon buttons across the bottom, each 341px wide × 52px tall:
+| Tab | Icon | Target Page |
+|-----|------|-------------|
+| Lights | mdi:lightbulb `\U000F0335` | `lights_page` |
+| Blinds & Fan | mdi:blinds-open `\U000F1011` | `blinds_fan_page` |
+| Entertainment | mdi:television `\U000F0502` | `entertainment_page` |
+
+Active tab = orange text, inactive = gray. Each `on_click` calls `lvgl.page.show` + updates all nav button colors.
+
+---
+
+## Page 1: LIGHTS (default page)
+
+**Layout:** `flex` / `column_wrap`, 4 columns × 3 rows of 200×130 buttons
+
+### Row 1–2: Light Controls (6 checkable buttons)
+| # | Label | Icon | Entity | Action | State Source |
+|---|-------|------|--------|--------|-------------|
+| 1 | All Lights | mdi:lightbulb-group `\U000F1253` | `light.living_room` | `light.toggle` | binary_sensor from `light.living_room` |
+| 2 | Tracks | mdi:track-light `\U000F0914` | `light.living_room_track_lights` | `light.toggle` | binary_sensor from `light.living_room_track_lights` |
+| 3 | Floor Lamp | mdi:floor-lamp `\U000F08DD` | `light.hue_color_lamp_1_5` | `light.toggle` | binary_sensor from entity |
+| 4 | Table Lamp | mdi:desk-lamp `\U000F095F` | `light.hue_color_lamp_1_4` | `light.toggle` | binary_sensor from entity |
+| 5 | TV Strip | mdi:led-strip `\U000F07D6` | `light.hue_play_gradient_lightstrip_1` | `light.toggle` | binary_sensor from entity |
+| 6 | Art Deco | mdi:lamp `\U000F06B5` | `light.living_room_art_deco_lamp` | `light.toggle` | binary_sensor from entity |
+
+### Row 3: Scene Buttons (4 non-checkable buttons, fire-and-forget)
+| # | Label | Icon | Entity | Action |
+|---|-------|------|--------|--------|
+| 7 | Relax | mdi:sofa `\U000F04B9` | `scene.living_room_relax` | `scene.turn_on` |
+| 8 | Watch TV | mdi:television-classic `\U000F07BC` | `scene.living_room_watch_tv` | `scene.turn_on` |
+| 9 | Natural | mdi:white-balance-sunny `\U000F05A8` | `scene.living_room_all_day_scene` | `scene.turn_on` |
+| 10 | All Off | mdi:power `\U000F0425` | `scene.time_for_bed` | `scene.turn_on` |
+
+Scene buttons are **not checkable** (no state tracking for now — user will add Stateful Scenes later).
+
+---
+
+## Page 2: BLINDS & FAN
+
+**Layout:** `flex` / `column_wrap`
+
+### Blind Controls (5 checkable buttons) — position-based checked state
+| # | Label | Icon | Position | State Logic |
+|---|-------|------|----------|-------------|
+| 1 | Open | mdi:blinds-open `\U000F1011` | 100 | `abs(position - 100) <= 3` |
+| 2 | 3/4 | mdi:blinds-open `\U000F1011` | 75 | `abs(position - 75) <= 3` |
+| 3 | Half | mdi:blinds-open `\U000F1011` | 50 | `abs(position - 50) <= 3` |
+| 4 | 1/4 | mdi:blinds-open `\U000F1011` | 25 | `abs(position - 25) <= 3` |
+| 5 | Closed | mdi:blinds-closed `\U000F00AC` | 0 | `abs(position - 0) <= 3` |
+
+All call `cover.set_cover_position` on `cover.living_room_blind`.
+
+### Fan Controls (4 checkable buttons) — speed-based checked state
+| # | Label | Icon | Action | State Logic |
+|---|-------|------|--------|-------------|
+| 6 | Off | mdi:fan-off `\U000F081D` | `fan.turn_off` | fan state == "off" |
+| 7 | Low | mdi:fan-speed-1 `\U000F1B04` | `fan.set_percentage: 33` | percentage ~33 |
+| 8 | Medium | mdi:fan-speed-2 `\U000F1B05` | `fan.set_percentage: 66` | percentage ~66 |
+| 9 | High | mdi:fan-speed-3 `\U000F1B06` | `fan.set_percentage: 100` | percentage ~100 |
+
+All target `fan.living_room_fans`. Fan percentage tracked via `sensor` → template `binary_sensor`.
+
+---
+
+## Page 3: ENTERTAINMENT
+
+**Layout:** `flex` / `column_wrap`
+
+### Device Power Controls (4 checkable buttons)
+| # | Label | Icon | Entity | Action | State Source |
+|---|-------|------|--------|--------|-------------|
+| 1 | TV | mdi:television `\U000F0502` | `media_player.living_room_tv` | `media_player.toggle` | binary_sensor from entity |
+| 2 | Apple TV | mdi:apple `\U000F0035` | `remote.living_room_apple_tv` | `remote.toggle` | binary_sensor from entity |
+| 3 | PS5 | mdi:sony-playstation `\U000F0414` | `switch.ps5_power` | `switch.toggle` | binary_sensor from entity |
+| 4 | Sonos | mdi:speaker `\U000F04C3` | `switch.sonos_living_room_plug` | `switch.toggle` | binary_sensor from entity |
+
+### Volume Controls (3 non-checkable buttons + 1 checkable mute)
+| # | Label | Icon | Entity | Action |
+|---|-------|------|--------|--------|
+| 5 | Vol + | mdi:volume-plus `\U000F075D` | `media_player.living_room_sonos` | `media_player.volume_up` |
+| 6 | Vol − | mdi:volume-minus `\U000F075E` | `media_player.living_room_sonos` | `media_player.volume_down` |
+| 7 | Mute | mdi:volume-mute `\U000F075F` | `media_player.living_room_sonos` | `media_player.volume_mute` (toggle) |
+
+Mute checked state tracked via `is_volume_muted` attribute on the Sonos entity.
+
+---
+
+## Files to Modify
+
+### 1. `guition-esp32-p4-jc1060p470/assets/icons.yaml` — **Full rewrite**
+Replace all office icons with ~25 living room icons + add `nav_icon_font` (28px) for bottom bar.
+
+**Icon glyphs needed:**
+```
+\U000F0335  mdi:lightbulb           (all lights + nav)
+\U000F1253  mdi:lightbulb-group     (all lights button)
+\U000F0914  mdi:track-light         (track lights)
+\U000F08DD  mdi:floor-lamp          (floor lamp)
+\U000F095F  mdi:desk-lamp           (table lamp)
+\U000F07D6  mdi:led-strip           (TV lightstrip)
+\U000F06B5  mdi:lamp                (art deco)
+\U000F04B9  mdi:sofa                (relax scene)
+\U000F07BC  mdi:television-classic  (watch TV scene)
+\U000F05A8  mdi:white-balance-sunny (natural light scene)
+\U000F0425  mdi:power               (all off)
+\U000F1011  mdi:blinds-open         (blind open + nav)
+\U000F00AC  mdi:blinds-closed       (blind closed)
+\U000F081D  mdi:fan-off             (fan off)
+\U000F1B04  mdi:fan-speed-1         (fan low)
+\U000F1B05  mdi:fan-speed-2         (fan medium)
+\U000F1B06  mdi:fan-speed-3         (fan high)
+\U000F0502  mdi:television          (TV + nav)
+\U000F0035  mdi:apple               (Apple TV)
+\U000F0414  mdi:sony-playstation    (PS5)
+\U000F04C3  mdi:speaker             (Sonos)
+\U000F075D  mdi:volume-plus         (vol up)
+\U000F075E  mdi:volume-minus        (vol down)
+\U000F075F  mdi:volume-mute         (mute)
+```
+
+### 2. `guition-esp32-p4-jc1060p470/assets/fonts.yaml` — **Minor addition**
+Keep existing 3 fonts. Add `nav_icon_font` (28px MDI for bottom nav bar icons).
+
+### 3. `guition-esp32-p4-jc1060p470/theme/button.yaml` — **Add nav styles**
+Keep existing button theme. Add:
+- `nav_button` style definition (bg: `0x1A1A1A`, text: gray, checked: orange)
+- Nav button dimensions: ~341px wide × 52px tall
+
+### 4. `guition-esp32-p4-jc1060p470/addon/backlight.yaml` — **One-line change**
+Change `entity_id: binary_sensor.office_presence_group` → `entity_id: binary_sensor.living_room_occupancy`
+
+### 5. `guition-esp32-p4-jc1060p470/device/sensors.yaml` — **Full rewrite**
+**Regular sensors:**
+- `sensor.living_room_temperature` → top bar indoor temp
+- `weather.openweathermap` (attribute: temperature) → top bar outdoor temp
+- `cover.living_room_blind` (attribute: current_position) → blind position tracking
+- `fan.living_room_fans` (attribute: percentage) → fan speed tracking
+- `media_player.living_room_sonos` (attribute: is_volume_muted) → mute state
+
+**Binary sensors (HA entity → button checked state):**
+- `light.living_room` → all_lights_button
+- `light.living_room_track_lights` → tracks_button
+- `light.hue_color_lamp_1_5` → floor_lamp_button
+- `light.hue_color_lamp_1_4` → table_lamp_button
+- `light.hue_play_gradient_lightstrip_1` → tv_strip_button
+- `light.living_room_art_deco_lamp` → art_deco_button
+- `media_player.living_room_tv` → tv_button
+- `remote.living_room_apple_tv` → appletv_button
+- `switch.ps5_power` → ps5_button
+- `switch.sonos_living_room_plug` → sonos_button
+
+**Template binary sensors (computed):**
+- 5 blind position sensors (100/75/50/25/0 ±3%)
+- 4 fan speed sensors (off / 33% / 66% / 100%)
+- 1 Sonos mute sensor (from is_volume_muted attribute)
+
+### 6. `guition-esp32-p4-jc1060p470/device/lvgl.yaml` — **Full rewrite**
+**top_layer:**
+- Temperature label (indoor/outdoor) — top left
+- Clock label — top center
+- Bottom nav bar with 3 tab buttons (Lights, Blinds & Fan, Entertainment)
+
+**pages:**
+- `lights_page` (default): 6 light buttons + 4 scene buttons
+- `blinds_fan_page`: 5 blind buttons + 4 fan buttons
+- `entertainment_page`: 4 power buttons + 3 volume buttons + mute
+
+### Files unchanged:
+- `esphome.yaml` — already configured
+- `package.yaml` — include list stays the same
+- `addon/time.yaml` — SNTP works universally
+- `addon/network.yaml` — WiFi diagnostics are device-level
+- `device/device.yaml` — hardware config unchanged
+
+---
+
+## Implementation Order
+
+1. `assets/icons.yaml` — icons first (everything else references them)
+2. `assets/fonts.yaml` — add nav icon font
+3. `theme/button.yaml` — add nav button style
+4. `addon/backlight.yaml` — quick presence entity swap
+5. `device/sensors.yaml` — all HA bindings (referenced by lvgl.yaml)
+6. `device/lvgl.yaml` — full UI (largest file, depends on all above)
+
+---
+
+## Verification
+
+1. **Compile:** `esphome compile guition-esp32-p4-jc1060p470/esphome.yaml` — must succeed without errors
+2. **Flash:** `esphome run guition-esp32-p4-jc1060p470/esphome.yaml` (OTA or USB)
+3. **Visual check:** 3 pages render correctly, bottom nav switches between them
+4. **Functional check:** Toggle lights, set blind positions, change fan speeds, control entertainment devices — verify all buttons trigger HA services and checked states sync back correctly
+5. **Top bar:** Temperature and clock display correctly
+6. **Screensaver:** Occupancy sensor triggers backlight on/off

--- a/guition-esp32-p4-jc1060p470/addon/backlight.yaml
+++ b/guition-esp32-p4-jc1060p470/addon/backlight.yaml
@@ -13,7 +13,7 @@ switch:
 binary_sensor:
   - platform: homeassistant
     id: presence
-    entity_id: binary_sensor.office_presence_group
+    entity_id: binary_sensor.living_room_occupancy
     on_press:
       - lvgl.resume:
       - delay: 10ms

--- a/guition-esp32-p4-jc1060p470/assets/icons.yaml
+++ b/guition-esp32-p4-jc1060p470/assets/icons.yaml
@@ -7,39 +7,73 @@ font:
     size: 48
     bpp: 8
     glyphs: [
-      "\U000F0335",  # mdi-lightbulb
-      "\U000F042B",  # mdi-printer-3d
-      "\U000F0D43",  # mdi-air-filter
-      "\U000F1051",  # mdi-led-strip-variant
-      "\U000F03D7",  # mdi-package-variant-closed
+      "\U000F1253",  # mdi-lightbulb-group
+      "\U000F0914",  # mdi-track-light
+      "\U000F08DD",  # mdi-floor-lamp
+      "\U000F095F",  # mdi-desk-lamp
       "\U000F07D6",  # mdi-led-strip
-      "\U000F00AC",  # mdi-blinds-closed
+      "\U000F06B5",  # mdi-lamp
+      "\U000F04B9",  # mdi-sofa
+      "\U000F07BC",  # mdi-television-classic
+      "\U000F05A8",  # mdi-white-balance-sunny
+      "\U000F0425",  # mdi-power
       "\U000F1011",  # mdi-blinds-open
-      "\U000F1A4C",  # mdi-lightbulb-night
-      "\U000F1087",  # mdi-router-network
-      "\U000F036B",  # mdi-message-video
-      "\U000F0614",  # mdi-application-outline
-      "\U000F089E",  # mdi-battery
-      "\U000F07DE",  # mdi-filament
-      "\U000F0317",  # mdi-lan
+      "\U000F00AC",  # mdi-blinds-closed
+      "\U000F081D",  # mdi-fan-off
+      "\U000F1B04",  # mdi-fan-speed-1
+      "\U000F1B05",  # mdi-fan-speed-2
+      "\U000F1B06",  # mdi-fan-speed-3
+      "\U000F0502",  # mdi-television
+      "\U000F0035",  # mdi-apple
+      "\U000F0414",  # mdi-sony-playstation
+      "\U000F04C3",  # mdi-speaker
+      "\U000F075D",  # mdi-volume-plus
+      "\U000F075E",  # mdi-volume-minus
+      "\U000F075F",  # mdi-volume-mute
+      ]
+
+  # Smaller icon font for bottom navigation bar
+  - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'
+    id: nav_icon_font
+    size: 28
+    bpp: 8
+    glyphs: [
+      "\U000F0335",  # mdi-lightbulb
+      "\U000F1011",  # mdi-blinds-open
+      "\U000F0502",  # mdi-television
       ]
 
 # Map icons to names
 substitutions:
-  lightbulb:      "\U000F0335"
-  printer:        "\U000F042B"
-  aircon:         "\U000F0D43"
-  ledstrip:       "\U000F1051"
-  led_strip_variant: "\U000F1051"
-  package:        "\U000F03D7"
-  lights:         "\U000F07D6"
-  blinds_closed:  "\U000F00AC"
-  blinds_open:    "\U000F1011"
-  nightlight:     "\U000F1A4C"
-  network:        "\U000F1087"
-  videocall:      "\U000F036B"
-  application:    "\U000F0614"
-  battery:        "\U000F089E"
-  filament:       "\U000F07DE"
-  lan:            "\U000F0317"
-
+  # Lights page
+  lightbulb_group:    "\U000F1253"
+  track_light:        "\U000F0914"
+  floor_lamp:         "\U000F08DD"
+  desk_lamp:          "\U000F095F"
+  led_strip:          "\U000F07D6"
+  lamp:               "\U000F06B5"
+  # Scenes
+  sofa:               "\U000F04B9"
+  television_classic: "\U000F07BC"
+  sunny:              "\U000F05A8"
+  power:              "\U000F0425"
+  # Blinds
+  blinds_open:        "\U000F1011"
+  blinds_closed:      "\U000F00AC"
+  # Fan
+  fan_off:            "\U000F081D"
+  fan_speed_1:        "\U000F1B04"
+  fan_speed_2:        "\U000F1B05"
+  fan_speed_3:        "\U000F1B06"
+  # Entertainment
+  television:         "\U000F0502"
+  apple:              "\U000F0035"
+  playstation:        "\U000F0414"
+  speaker:            "\U000F04C3"
+  volume_plus:        "\U000F075D"
+  volume_minus:       "\U000F075E"
+  volume_mute:        "\U000F075F"
+  # Navigation bar
+  nav_lightbulb:      "\U000F0335"
+  nav_blinds:         "\U000F1011"
+  nav_tv:             "\U000F0502"

--- a/guition-esp32-p4-jc1060p470/device/lvgl.yaml
+++ b/guition-esp32-p4-jc1060p470/device/lvgl.yaml
@@ -1,11 +1,11 @@
 lvgl:
   displays: my_display
   byte_order: little_endian
-  
+
   top_layer:
     widgets:
-    
-      # Temperature
+
+      # Temperature (outdoor / indoor)
       - label:
           text: "-° / -°"
           id: temperatures
@@ -25,10 +25,105 @@ lvgl:
           y: 8
           text_align: center
           text_color: 0xFFFFFF
-          
+
+      # ===========================
+      # BOTTOM NAVIGATION BAR
+      # ===========================
+      - obj:
+          align: bottom_left
+          width: 100%
+          height: 56
+          bg_color: 0x1A1A1A
+          bg_opa: COVER
+          border_width: 0
+          pad_all: 0
+          layout:
+            type: flex
+            flex_flow: row
+          widgets:
+
+            # Nav: Lights
+            - button:
+                id: nav_lights_button
+                width: 341
+                height: 52
+                styles: nav_button_active
+                checkable: false
+                widgets:
+                  - label:
+                      text_font: nav_icon_font
+                      align: center
+                      text: $nav_lightbulb
+                on_click:
+                  - lvgl.page.show: lights_page
+                  - lvgl.widget.update:
+                      id: nav_lights_button
+                      styles: nav_button_active
+                  - lvgl.widget.update:
+                      id: nav_blinds_button
+                      styles: nav_button
+                  - lvgl.widget.update:
+                      id: nav_entertainment_button
+                      styles: nav_button
+
+            # Nav: Blinds & Fan
+            - button:
+                id: nav_blinds_button
+                width: 341
+                height: 52
+                styles: nav_button
+                checkable: false
+                widgets:
+                  - label:
+                      text_font: nav_icon_font
+                      align: center
+                      text: $nav_blinds
+                on_click:
+                  - lvgl.page.show: blinds_fan_page
+                  - lvgl.widget.update:
+                      id: nav_lights_button
+                      styles: nav_button
+                  - lvgl.widget.update:
+                      id: nav_blinds_button
+                      styles: nav_button_active
+                  - lvgl.widget.update:
+                      id: nav_entertainment_button
+                      styles: nav_button
+
+            # Nav: Entertainment
+            - button:
+                id: nav_entertainment_button
+                width: 342
+                height: 52
+                styles: nav_button
+                checkable: false
+                widgets:
+                  - label:
+                      text_font: nav_icon_font
+                      align: center
+                      text: $nav_tv
+                on_click:
+                  - lvgl.page.show: entertainment_page
+                  - lvgl.widget.update:
+                      id: nav_lights_button
+                      styles: nav_button
+                  - lvgl.widget.update:
+                      id: nav_blinds_button
+                      styles: nav_button
+                  - lvgl.widget.update:
+                      id: nav_entertainment_button
+                      styles: nav_button_active
+
+  # ===========================
+  # PAGES
+  # ===========================
   pages:
-    - id: main_page
-      layout: 
+
+    # ===========================
+    # PAGE 1: LIGHTS & SCENES
+    # ===========================
+    - id: lights_page
+      layout:
         type: flex
         flex_flow: column_wrap
         pad_row: 10
@@ -37,110 +132,244 @@ lvgl:
       bg_color: Black
       bg_opa: cover
       pad_top: 42
-      pad_bottom: 5
+      pad_bottom: 60
       pad_left: 5
       pad_right: 5
-      
+
       widgets:
-      
-        # Office Features Scene
-        - button: 
+
+        # All Lights
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_scene_features_button
+            id: lr_all_lights_button
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: scene_features_icon                
-                  text: $ledstrip
+                  text: $lightbulb_group
               - label:
                   align: bottom_left
-                  id: scene_features_label
-                  text: "Features"
-            on_press:
+                  text: "All Lights"
+            on_click:
               - homeassistant.service:
-                  service: switch.toggle
+                  service: light.toggle
                   data:
-                    entity_id: switch.office_features_stateful_scene
+                    entity_id: light.living_room
 
-        # Office Calls Scene
-        - button: 
+        # Track Lights
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_scene_calls_button
+            id: lr_tracks_button
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: office_scene_calls_icon                
-                  text: $videocall
+                  text: $track_light
               - label:
                   align: bottom_left
-                  id: office_scene_calls_label
-                  text: "Calls"
-            on_press:
+                  text: "Tracks"
+            on_click:
               - homeassistant.service:
-                  service: switch.toggle
+                  service: light.toggle
                   data:
-                    entity_id: switch.office_calls_stateful_scene
+                    entity_id: light.living_room_track_lights
 
-        # Office Evening Scene
-        - button: 
+        # Floor Lamp
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_scene_evening_button
+            id: lr_floor_lamp_button
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: office_scene_evening_icon                
-                  text: $nightlight
+                  text: $floor_lamp
               - label:
                   align: bottom_left
-                  id: office_scene_evening_label
-                  text: "Evening"
-            on_press:
+                  text: "Floor Lamp"
+            on_click:
               - homeassistant.service:
-                  service: switch.toggle
+                  service: light.toggle
                   data:
-                    entity_id: switch.office_evening_stateful_scene
+                    entity_id: light.hue_color_lamp_1_5
 
-        # Office Dimmed Scene
-        - button: 
+        # Table Lamp
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_scene_dimmed_button
+            id: lr_table_lamp_button
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: office_scene_dimmed_icon                
-                  text: $nightlight
+                  text: $desk_lamp
               - label:
                   align: bottom_left
-                  id: office_scene_dimmed_label
-                  text: "Dimmed"
-            on_press:
+                  text: "Table Lamp"
+            on_click:
               - homeassistant.service:
-                  service: switch.toggle
+                  service: light.toggle
                   data:
-                    entity_id: switch.office_dimmed_stateful_scene
+                    entity_id: light.hue_color_lamp_1_4
 
-        # Office Blind 100%
-        - button: 
+        # TV Lightstrip
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_blind_open_button
+            id: lr_tv_strip_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $led_strip
+              - label:
+                  align: bottom_left
+                  text: "TV Strip"
+            on_click:
+              - homeassistant.service:
+                  service: light.toggle
+                  data:
+                    entity_id: light.hue_play_gradient_lightstrip_1
+
+        # Art Deco Lamp
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_art_deco_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $lamp
+              - label:
+                  align: bottom_left
+                  text: "Art Deco"
+            on_click:
+              - homeassistant.service:
+                  service: light.toggle
+                  data:
+                    entity_id: light.living_room_art_deco_lamp
+
+        # Scene: Relax
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: false
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $sofa
+              - label:
+                  align: bottom_left
+                  text: "Relax"
+            on_click:
+              - homeassistant.service:
+                  service: scene.turn_on
+                  data:
+                    entity_id: scene.living_room_relax
+
+        # Scene: Watch TV
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: false
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $television_classic
+              - label:
+                  align: bottom_left
+                  text: "Watch TV"
+            on_click:
+              - homeassistant.service:
+                  service: scene.turn_on
+                  data:
+                    entity_id: scene.living_room_watch_tv
+
+        # Scene: Natural Light
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: false
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $sunny
+              - label:
+                  align: bottom_left
+                  text: "Natural"
+            on_click:
+              - homeassistant.service:
+                  service: scene.turn_on
+                  data:
+                    entity_id: scene.living_room_all_day_scene
+
+        # Scene: All Off
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: false
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $power
+              - label:
+                  align: bottom_left
+                  text: "All Off"
+            on_click:
+              - homeassistant.service:
+                  service: scene.turn_on
+                  data:
+                    entity_id: scene.time_for_bed
+
+
+    # ===========================
+    # PAGE 2: BLINDS & FAN
+    # ===========================
+    - id: blinds_fan_page
+      layout:
+        type: flex
+        flex_flow: column_wrap
+        pad_row: 10
+        pad_column: 10
+      width: 100%
+      bg_color: Black
+      bg_opa: cover
+      pad_top: 42
+      pad_bottom: 60
+      pad_left: 5
+      pad_right: 5
+
+      widgets:
+
+        # Blind: Open (100%)
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_blind_open_button
             styles: control
             widgets:
               - label:
@@ -154,15 +383,15 @@ lvgl:
               - homeassistant.service:
                   service: cover.set_cover_position
                   data:
-                    entity_id: cover.office_blind
+                    entity_id: cover.living_room_blind
                     position: "100"
 
-        # Office Blind 66%
-        - button: 
+        # Blind: 3/4 Open (75%)
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_blind_66_button
+            id: lr_blind_75_button
             styles: control
             widgets:
               - label:
@@ -171,20 +400,20 @@ lvgl:
                   text: $blinds_open
               - label:
                   align: bottom_left
-                  text: "Semi Open"
+                  text: "3/4 Open"
             on_click:
               - homeassistant.service:
                   service: cover.set_cover_position
                   data:
-                    entity_id: cover.office_blind
-                    position: "66"
+                    entity_id: cover.living_room_blind
+                    position: "75"
 
-        # Office Blind 33%
-        - button: 
+        # Blind: Half (50%)
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_blind_33_button
+            id: lr_blind_50_button
             styles: control
             widgets:
               - label:
@@ -193,20 +422,42 @@ lvgl:
                   text: $blinds_open
               - label:
                   align: bottom_left
-                  text: "Semi Closed"
+                  text: "Half"
             on_click:
               - homeassistant.service:
                   service: cover.set_cover_position
                   data:
-                    entity_id: cover.office_blind
-                    position: "33"
+                    entity_id: cover.living_room_blind
+                    position: "50"
 
-        # Office Blind 0%
-        - button: 
+        # Blind: 1/4 Open (25%)
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: office_blind_close_button
+            id: lr_blind_25_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $blinds_open
+              - label:
+                  align: bottom_left
+                  text: "1/4 Open"
+            on_click:
+              - homeassistant.service:
+                  service: cover.set_cover_position
+                  data:
+                    entity_id: cover.living_room_blind
+                    position: "25"
+
+        # Blind: Closed (0%)
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_blind_closed_button
             styles: control
             widgets:
               - label:
@@ -215,198 +466,263 @@ lvgl:
                   text: $blinds_closed
               - label:
                   align: bottom_left
-                  text: "Close"
+                  text: "Closed"
             on_click:
               - homeassistant.service:
                   service: cover.set_cover_position
                   data:
-                    entity_id: cover.office_blind
+                    entity_id: cover.living_room_blind
                     position: "0"
 
-
-        # 3d Printer
-        - button: 
+        # Fan: Off
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: printer_power_button
+            id: lr_fan_off_button
             styles: control
             widgets:
-              # Icon (shown when OFF)
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: printer_power_icon
-                  text: $printer
-              # Progress (shown when ON)
-              - obj:
-                  align: top_left
-                  id: print_progress_container
-                  height: SIZE_CONTENT
-                  width: SIZE_CONTENT
-                  clickable: false
-                  layout:
-                    type: flex
-                    flex_flow: row
-                    flex_align_cross: end
-                  bg_opa: TRANSP
-                  border_width: 0
-                  pad_all: 0
-                  hidden: true
-                  widgets:
-                    - label:
-                        text_font: statistics_font
-                        text_color: $button_text_color
-                        id: print_progress_label
-                        text: "--"
-                    - label:
-                        text_font: label_font
-                        text_color: $button_text_color
-                        text: "%"
-                        pad_bottom: 6
+                  text: $fan_off
               - label:
                   align: bottom_left
-                  text: "Printer"
+                  text: "Fan Off"
+            on_click:
+              - homeassistant.service:
+                  service: fan.turn_off
+                  data:
+                    entity_id: fan.living_room_fans
+
+        # Fan: Low (33%)
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_fan_low_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $fan_speed_1
+              - label:
+                  align: bottom_left
+                  text: "Fan Low"
+            on_click:
+              - homeassistant.service:
+                  service: fan.set_percentage
+                  data:
+                    entity_id: fan.living_room_fans
+                    percentage: 33
+
+        # Fan: Medium (66%)
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_fan_med_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $fan_speed_2
+              - label:
+                  align: bottom_left
+                  text: "Fan Med"
+            on_click:
+              - homeassistant.service:
+                  service: fan.set_percentage
+                  data:
+                    entity_id: fan.living_room_fans
+                    percentage: 66
+
+        # Fan: High (100%)
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_fan_high_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $fan_speed_3
+              - label:
+                  align: bottom_left
+                  text: "Fan High"
+            on_click:
+              - homeassistant.service:
+                  service: fan.set_percentage
+                  data:
+                    entity_id: fan.living_room_fans
+                    percentage: 100
+
+
+    # ===========================
+    # PAGE 3: ENTERTAINMENT
+    # ===========================
+    - id: entertainment_page
+      layout:
+        type: flex
+        flex_flow: column_wrap
+        pad_row: 10
+        pad_column: 10
+      width: 100%
+      bg_color: Black
+      bg_opa: cover
+      pad_top: 42
+      pad_bottom: 60
+      pad_left: 5
+      pad_right: 5
+
+      widgets:
+
+        # TV Power
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_tv_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $television
+              - label:
+                  align: bottom_left
+                  text: "TV"
+            on_click:
+              - homeassistant.service:
+                  service: media_player.toggle
+                  data:
+                    entity_id: media_player.living_room_tv
+
+        # Apple TV
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_appletv_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $apple
+              - label:
+                  align: bottom_left
+                  text: "Apple TV"
+            on_click:
+              - homeassistant.service:
+                  service: remote.toggle
+                  data:
+                    entity_id: remote.living_room_apple_tv
+
+        # PS5
+        - button:
+            height: $button_height
+            width: $button_width
+            checkable: true
+            id: lr_ps5_button
+            styles: control
+            widgets:
+              - label:
+                  text_font: $icon_font
+                  align: top_left
+                  text: $playstation
+              - label:
+                  align: bottom_left
+                  text: "PS5"
             on_click:
               - homeassistant.service:
                   service: switch.toggle
                   data:
-                    entity_id: switch.office_3d_printer_power
+                    entity_id: switch.ps5_power
 
-        # Filament Heater
-        - button: 
+        # Sonos
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: filament_heater_button
+            id: lr_sonos_button
             styles: control
             widgets:
-              # Icon (shown when OFF)
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: filament_heater_icon
-                  text: $filament
-              # Humidity (shown when ON)
-              - obj:
-                  align: top_left
-                  id: dryer_humidity_container
-                  height: SIZE_CONTENT
-                  width: SIZE_CONTENT
-                  clickable: false
-                  layout:
-                    type: flex
-                    flex_flow: row
-                    flex_align_cross: end
-                  bg_opa: TRANSP
-                  border_width: 0
-                  pad_all: 0
-                  hidden: true
-                  widgets:
-                    - label:
-                        text_font: statistics_font
-                        text_color: $button_text_color
-                        id: dryer_humidity_label
-                        text: "--"
-                    - label:
-                        text_font: label_font
-                        text_color: $button_text_color
-                        text: "%"
-                        pad_bottom: 6
-                        pad_left: -4
+                  text: $speaker
               - label:
                   align: bottom_left
-                  text: "Dryer"
+                  text: "Sonos"
             on_click:
               - homeassistant.service:
                   service: switch.toggle
                   data:
-                    entity_id: switch.office_filament_heater_893b
+                    entity_id: switch.sonos_living_room_plug
 
-        # Office Aircon
-        - button: 
+        # Volume Up
+        - button:
             height: $button_height
             width: $button_width
-            checkable: true
-            id: office_aircon_button
+            checkable: false
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  text: $aircon
+                  text: $volume_plus
               - label:
                   align: bottom_left
-                  text: "Aircon"
+                  text: "Vol +"
             on_click:
               - homeassistant.service:
-                  service: script.office_air_conditioner
-
-        # Battery Charger
-        - button: 
-            height: $button_height
-            width: $button_width
-            checkable: true
-            id: battery_charger_button
-            styles: control
-            widgets:
-              - label:
-                  text_font: $icon_font
-                  align: top_left
-                  id: battery_charger_icon
-                  text: $battery
-              - label:
-                  align: bottom_left
-                  id: battery_charger_label
-                  text: "Charger"
-            on_click:
-              - homeassistant.service:
-                  service: switch.toggle
+                  service: media_player.volume_up
                   data:
-                    entity_id: switch.battery_charger
+                    entity_id: media_player.living_room_sonos
 
-        # Storage Lights
-        - button: 
+        # Volume Down
+        - button:
             height: $button_height
             width: $button_width
-            checkable: true
-            id: storage_lights_button
+            checkable: false
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: storage_lights_icon
-                  text: $package
+                  text: $volume_minus
               - label:
                   align: bottom_left
-                  id: storage_lights_label
-                  text: "Storage"
+                  text: "Vol -"
             on_click:
               - homeassistant.service:
-                  service: light.toggle
+                  service: media_player.volume_down
                   data:
-                    entity_id: light.office_storage
+                    entity_id: media_player.living_room_sonos
 
-        # Network Rack
-        - button: 
+        # Mute
+        - button:
             height: $button_height
             width: $button_width
             checkable: true
-            id: network_rack_button
+            id: lr_mute_button
             styles: control
             widgets:
               - label:
                   text_font: $icon_font
                   align: top_left
-                  id: network_rack_icon
-                  text: $network
+                  text: $volume_mute
               - label:
                   align: bottom_left
-                  id: network_rack_label
-                  text: "Network Rack"
+                  text: "Mute"
             on_click:
               - homeassistant.service:
-                  service: light.toggle
+                  service: media_player.volume_mute
                   data:
-                    entity_id: light.office_network_rack
+                    entity_id: media_player.living_room_sonos
+                    is_volume_muted: !lambda return !id(lr_sonos_muted).state;

--- a/guition-esp32-p4-jc1060p470/device/sensors.yaml
+++ b/guition-esp32-p4-jc1060p470/device/sensors.yaml
@@ -1,9 +1,9 @@
 sensor:
 
-  # Header Outdoor Temperate
+  # Header Indoor Temperature
   - platform: homeassistant
-    entity_id: sensor.office_temperature
-    id: office_temperature
+    entity_id: sensor.living_room_temperature
+    id: living_room_temperature
     on_value:
       - lvgl.label.update:
           id: temperatures
@@ -11,236 +11,310 @@ sensor:
             format: "%d° / %d°"
             args: [ '(int)round(id(outdoor_temperature).state)', '(int)round(x)' ]
 
+  # Header Outdoor Temperature (from weather entity)
   - platform: homeassistant
-    entity_id: sensor.outdoor_temperature
+    entity_id: weather.openweathermap
     id: outdoor_temperature
+    attribute: temperature
     on_value:
       - lvgl.label.update:
           id: temperatures
           text:
             format: "%d° / %d°"
-            args: [ '(int)round(x)', '(int)round(id(office_temperature).state)' ]
+            args: [ '(int)round(x)', '(int)round(id(living_room_temperature).state)' ]
 
-  # Office Blind Position
+  # Blind Position
   - platform: homeassistant
-    entity_id: cover.office_blind
-    id: office_blind_position
+    entity_id: cover.living_room_blind
+    id: lr_blind_position
     attribute: current_position
 
-  # Centauri Carbon Print Progress
+  # Fan Speed Percentage
   - platform: homeassistant
-    entity_id: sensor.centauri_carbon_percent_complete_helper
-    id: centauri_carbon_percent
-    on_value:
-      - lvgl.label.update:
-          id: print_progress_label
-          text:
-            format: "%.0f"
-            args: [ 'x' ]
-
-  # Filament Heater Humidity
-  - platform: homeassistant
-    entity_id: sensor.office_filament_heater_sensor_humidity
-    id: filament_heater_humidity
-    on_value:
-      - lvgl.label.update:
-          id: dryer_humidity_label
-          text:
-            format: "%.0f"
-            args: [ 'x' ]
-
+    entity_id: fan.living_room_fans
+    id: lr_fan_percentage
+    attribute: percentage
 
 
 binary_sensor:
 
-  # Office Evening Scene
+  # ===========================
+  # LIGHTS PAGE - State Sync
+  # ===========================
+
+  # All Lights (Hue group)
   - platform: homeassistant
-    id: office_scene_evening
-    entity_id: switch.office_evening_stateful_scene
+    id: lr_all_lights
+    entity_id: light.living_room
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: office_scene_evening_button
+          id: lr_all_lights_button
           state:
             checked: !lambda return x;
 
-  # Office Dimmed Scene
+  # Track Lights (group)
   - platform: homeassistant
-    id: office_scene_dimmed
-    entity_id: switch.office_dimmed_stateful_scene
+    id: lr_tracks
+    entity_id: light.living_room_track_lights
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: office_scene_dimmed_button
+          id: lr_tracks_button
           state:
             checked: !lambda return x;
 
-  # Office Calls Scene
+  # Floor Lamp
   - platform: homeassistant
-    id: office_scene_desk_call
-    entity_id: switch.office_calls_stateful_scene
+    id: lr_floor_lamp
+    entity_id: light.hue_color_lamp_1_5
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: office_scene_calls_button
+          id: lr_floor_lamp_button
           state:
             checked: !lambda return x;
 
-  # Office Features Scene
+  # Table Lamp
   - platform: homeassistant
-    id: office_scene_features
-    entity_id: switch.office_features_stateful_scene
+    id: lr_table_lamp
+    entity_id: light.hue_color_lamp_1_4
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: office_scene_features_button
+          id: lr_table_lamp_button
           state:
             checked: !lambda return x;
 
-  # 3d Printer
+  # TV Lightstrip
   - platform: homeassistant
-    id: office_3d_printer_power
-    entity_id: switch.office_3d_printer_power
+    id: lr_tv_strip
+    entity_id: light.hue_play_gradient_lightstrip_1
+    trigger_on_initial_state: true
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_tv_strip_button
+          state:
+            checked: !lambda return x;
+
+  # Art Deco Lamp
+  - platform: homeassistant
+    id: lr_art_deco
+    entity_id: light.living_room_art_deco_lamp
+    trigger_on_initial_state: true
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_art_deco_button
+          state:
+            checked: !lambda return x;
+
+  # ===========================
+  # BLINDS PAGE - Position Sync
+  # ===========================
+
+  # Blind Open (100%)
+  - platform: template
+    id: lr_blind_100
+    lambda: |-
+      if (id(lr_blind_position).has_state()) {
+        return abs(id(lr_blind_position).state - 100) <= 3;
+      }
+      return false;
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_blind_open_button
+          state:
+            checked: !lambda return x;
+
+  # Blind 3/4 Open (75%)
+  - platform: template
+    id: lr_blind_75
+    lambda: |-
+      if (id(lr_blind_position).has_state()) {
+        return abs(id(lr_blind_position).state - 75) <= 3;
+      }
+      return false;
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_blind_75_button
+          state:
+            checked: !lambda return x;
+
+  # Blind Half (50%)
+  - platform: template
+    id: lr_blind_50
+    lambda: |-
+      if (id(lr_blind_position).has_state()) {
+        return abs(id(lr_blind_position).state - 50) <= 3;
+      }
+      return false;
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_blind_50_button
+          state:
+            checked: !lambda return x;
+
+  # Blind 1/4 Open (25%)
+  - platform: template
+    id: lr_blind_25
+    lambda: |-
+      if (id(lr_blind_position).has_state()) {
+        return abs(id(lr_blind_position).state - 25) <= 3;
+      }
+      return false;
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_blind_25_button
+          state:
+            checked: !lambda return x;
+
+  # Blind Closed (0%)
+  - platform: template
+    id: lr_blind_0
+    lambda: |-
+      if (id(lr_blind_position).has_state()) {
+        return abs(id(lr_blind_position).state - 0) <= 3;
+      }
+      return false;
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_blind_closed_button
+          state:
+            checked: !lambda return x;
+
+  # ===========================
+  # FAN PAGE - Speed Sync
+  # ===========================
+
+  # Fan Off
+  - platform: homeassistant
+    id: lr_fan_state
+    entity_id: fan.living_room_fans
     trigger_on_initial_state: true
     on_state:
       then:
         - lvgl.widget.update:
-            id: printer_power_button
+            id: lr_fan_off_button
             state:
-              checked: !lambda return x;
-        - lvgl.widget.update:
-            id: printer_power_icon
-            hidden: !lambda return x;
-        - lvgl.widget.update:
-            id: print_progress_container
-            hidden: !lambda return !x;
+              checked: !lambda return !x;
 
-  # Office Aircon
-  - platform: homeassistant
-    id: office_air_conditioner
-    entity_id: switch.office_air_conditioner
-    trigger_on_initial_state: true
-    on_state:
-      then:
-        lvgl.widget.update:
-          id: office_aircon_button
-          state:
-            checked: !lambda return x;
-
-  # Battery Charger
-  - platform: homeassistant
-    id: office_battery_charger
-    entity_id: switch.battery_charger
-    trigger_on_initial_state: true
-    on_state:
-      then:
-        lvgl.widget.update:
-          id: battery_charger_button
-          state:
-            checked: !lambda return x;
-
-  # Filament Heater 
-  - platform: homeassistant
-    id: office_filament_heater
-    entity_id: switch.office_filament_heater_893b
-    trigger_on_initial_state: true
-    on_state:
-      then:
-        - lvgl.widget.update:
-            id: filament_heater_button
-            state:
-              checked: !lambda return x;
-        - lvgl.widget.update:
-            id: filament_heater_icon
-            hidden: !lambda return x;
-        - lvgl.widget.update:
-            id: dryer_humidity_container
-            hidden: !lambda return !x;
-
-  # Office Blind 100% (Open)
+  # Fan Low (~33%)
   - platform: template
-    id: office_blind_100
+    id: lr_fan_low
     lambda: |-
-      if (id(office_blind_position).has_state()) {
-        return abs(id(office_blind_position).state - 100) <= 3;
+      if (id(lr_fan_percentage).has_state() && id(lr_fan_state).state) {
+        return abs(id(lr_fan_percentage).state - 33) <= 5;
       }
       return false;
     on_state:
       then:
         lvgl.widget.update:
-          id: office_blind_open_button
+          id: lr_fan_low_button
           state:
             checked: !lambda return x;
 
-  # Office Blind 66% (Semi Open)
+  # Fan Medium (~66%)
   - platform: template
-    id: office_blind_66
+    id: lr_fan_med
     lambda: |-
-      if (id(office_blind_position).has_state()) {
-        return abs(id(office_blind_position).state - 66) <= 3;
+      if (id(lr_fan_percentage).has_state() && id(lr_fan_state).state) {
+        return abs(id(lr_fan_percentage).state - 66) <= 5;
       }
       return false;
     on_state:
       then:
         lvgl.widget.update:
-          id: office_blind_66_button
+          id: lr_fan_med_button
           state:
             checked: !lambda return x;
 
-  # Office Blind 33% (Semi Closed)
+  # Fan High (~100%)
   - platform: template
-    id: office_blind_33
+    id: lr_fan_high
     lambda: |-
-      if (id(office_blind_position).has_state()) {
-        return abs(id(office_blind_position).state - 33) <= 3;
+      if (id(lr_fan_percentage).has_state() && id(lr_fan_state).state) {
+        return abs(id(lr_fan_percentage).state - 100) <= 5;
       }
       return false;
     on_state:
       then:
         lvgl.widget.update:
-          id: office_blind_33_button
+          id: lr_fan_high_button
           state:
             checked: !lambda return x;
 
-  # Office Blind 0% (Close)
-  - platform: template
-    id: office_blind_0
-    lambda: |-
-      if (id(office_blind_position).has_state()) {
-        return abs(id(office_blind_position).state - 0) <= 3;
-      }
-      return false;
-    on_state:
-      then:
-        lvgl.widget.update:
-          id: office_blind_close_button
-          state:
-            checked: !lambda return x;
+  # ===========================
+  # ENTERTAINMENT PAGE - State Sync
+  # ===========================
 
-  # Office Storage Lights
+  # TV Power
   - platform: homeassistant
-    id: office_storage_lights
-    entity_id: light.office_storage
+    id: lr_tv_power
+    entity_id: media_player.living_room_tv
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: storage_lights_button
+          id: lr_tv_button
           state:
             checked: !lambda return x;
 
-  # Network Rack
+  # Apple TV
   - platform: homeassistant
-    id: network_rack
-    entity_id: light.office_network_rack
+    id: lr_appletv
+    entity_id: remote.living_room_apple_tv
     trigger_on_initial_state: true
     on_state:
       then:
         lvgl.widget.update:
-          id: network_rack_button
+          id: lr_appletv_button
+          state:
+            checked: !lambda return x;
+
+  # PS5 Power
+  - platform: homeassistant
+    id: lr_ps5
+    entity_id: switch.ps5_power
+    trigger_on_initial_state: true
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_ps5_button
+          state:
+            checked: !lambda return x;
+
+  # Sonos Plug
+  - platform: homeassistant
+    id: lr_sonos
+    entity_id: switch.sonos_living_room_plug
+    trigger_on_initial_state: true
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_sonos_button
+          state:
+            checked: !lambda return x;
+
+  # Sonos Mute State
+  - platform: homeassistant
+    id: lr_sonos_muted
+    entity_id: media_player.living_room_sonos
+    attribute: is_volume_muted
+    trigger_on_initial_state: true
+    on_state:
+      then:
+        lvgl.widget.update:
+          id: lr_mute_button
           state:
             checked: !lambda return x;

--- a/guition-esp32-p4-jc1060p470/theme/button.yaml
+++ b/guition-esp32-p4-jc1060p470/theme/button.yaml
@@ -7,11 +7,32 @@ substitutions:
   button_width: 200px
   padding: 14px
   radius: 8px
+  nav_active_color: "0xFF8C00"
+  nav_inactive_color: "0x808080"
+  nav_bg_color: "0x1A1A1A"
 
 lvgl:
   style_definitions:
     - id: control
       bg_color: $button_control_color
+
+    - id: nav_button
+      bg_color: $nav_bg_color
+      bg_opa: COVER
+      radius: 0
+      pad_all: 4
+      shadow_width: 0
+      border_width: 0
+      text_color: $nav_inactive_color
+
+    - id: nav_button_active
+      bg_color: $nav_bg_color
+      bg_opa: COVER
+      radius: 0
+      pad_all: 4
+      shadow_width: 0
+      border_width: 0
+      text_color: $nav_active_color
 
   theme:
     button:


### PR DESCRIPTION
Replace the office dashboard with a full living room dashboard featuring 3 pages (Lights & Scenes, Blinds & Fan, Entertainment) with a bottom navigation bar, top bar with temperature/clock, and 20+ buttons with full Home Assistant state sync.

- Lights page: 6 individual light controls + 4 scene buttons
- Blinds & Fan page: 5 blind position presets + 4 fan speed controls
- Entertainment page: TV, Apple TV, PS5, Sonos power + volume controls
- Bottom nav bar with active tab highlighting
- Presence-based screensaver via living room occupancy sensor
- Add CLAUDE.md and PLAN.md for project documentation